### PR TITLE
Add timestamps to feedback statistics

### DIFF
--- a/popup/popup.html
+++ b/popup/popup.html
@@ -39,7 +39,7 @@
         </div>
       </div>
       <div id="completed-timer-completed-feedback" class="cls-hidden">
-        <p>Thank you for your feedback. You can check your statistics <a href="#">here</a>.</p>
+        <p>Thank you for your feedback. You can check your statistics <a href="#" class="stats-page-links">here</a>.</p>
       </div>
       <hr />
       <div class="d-flex justify-content-center p-3">
@@ -52,11 +52,11 @@
       <a href="#" id="options-page-link">Options</a>
     </div>
     <div class="options-container text-center">
-      <a href="#" id="stats-page-link">My Stats</a>
+      <a href="#" class="stats-page-links">My Stats</a>
     </div>
   </div>
   <script src="../scripts/utils.js"></script>
-  <script src="../scripts/content_scripts/utils_chrome_api.js" type="module"></script>
+  <script src="../scripts/content_scripts/utils_chrome_api.js"></script>
   <script src="popup.js"></script>
 </body>
 

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -66,11 +66,16 @@ Array.from(document.getElementsByClassName(PURCHASE_FEEDBACK_BTNS_CLASS)).forEac
             var url = getCurrentTabUrl(tabs);
             // TODO: Streamline this logic
             // Determine if the purchase was deferred based on the button's dataset
-
-            const wasDeferred = event.target.dataset.proceededWithPurchase === "y" ? false : true;
-            chrome.runtime.sendMessage({ action: 'add-purchase-stat', url: url, initiator: 'popup', wasDeferred: wasDeferred }).then(() => {
-                // Handle the UI updates after feedback submission
-                handlePostFeedbackSubmission()
+            getStoredTime(url).then((timerEndTime) => {
+                const wasDeferred = event.target.dataset.proceededWithPurchase === "y" ? false : true;
+                chrome.runtime.sendMessage(
+                    {
+                        action: 'add-purchase-stat', url: url, initiator: 'popup',
+                        wasDeferred: wasDeferred, timerEndTime: timerEndTime
+                    }).then(() => {
+                        // Handle the UI updates after feedback submission
+                        handlePostFeedbackSubmission()
+                    })
             })
         })
     })
@@ -88,9 +93,10 @@ document.getElementById(OPTIONS_PAGE_LINK_ID).addEventListener("click", () => {
  * Adds a click event listener to the "Statistics Page" link.
  * When clicked, it opens the user statistics page.
  */
-document.getElementById(STATS_PAGE_LINK_ID).addEventListener("click", () => {
+Array.from(document.getElementsByClassName(STATS_PAGE_LINK_CLASS)).forEach(element => {
+    element.addEventListener("click", () => {
     openPage(STATS_PAGE_NAME)
-})
+})})
 /**
  * Checks if any active interventions (timers) exist in storage.
  * If a timer exists, it updates the "Add Timer" button's styling to indicate its disabled state.
@@ -99,6 +105,7 @@ function checkActiveInterventions() {
     chrome.storage.local.get({ timer: true }).then(
         (items) => {
             if (items.timer == true) {
+                //TODO: Add message informing user the intervention is disabled
                 document.getElementById(ADD_TIMER_BTN_ID).classList.add(['dull-buy-btn'])
             }
         }

--- a/scripts/background/background.js
+++ b/scripts/background/background.js
@@ -45,8 +45,9 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     } else if (message.action === ADD_PURCHASE_TIMER_STAT) {
         const url = message.url
         const wasDeferred = message.wasDeferred
+        const timerEndTime = message.timerEndTime
         // Record the purchase deferment and respond once completed
-        recordPurchaseDeferment(url, wasDeferred).then(() => { sendResponse("Completed") })
+        recordPurchaseDeferment(url, wasDeferred, timerEndTime).then(() => { sendResponse("Completed") })
 
     }
     // Indicate that the response will be sent asynchronously

--- a/scripts/background/utils_chrome_api.js
+++ b/scripts/background/utils_chrome_api.js
@@ -1,8 +1,5 @@
 // Time constant representing 24 hours in milliseconds
 const twentyFourHours = 24 * 60 * 60000;
-// Keys used for storing deferred and completed purchase data in Chrome's local storage
-const DEFERRED_PURCHASES_STORE_KEY = "deferred_purchases"
-const COMPLETED_PURCHASES_STORE_KEY = "completed_purchases"
 
 /**
  * Retrieves the stored time for a given URL from Chrome's local storage.
@@ -77,7 +74,7 @@ function sendMessageToContentScript(url, action, endTime = null, requestInitiato
  * @param {boolean} wasDeferred - True if the purchase was deferred, false if completed.
  * @returns {Promise<void>} A promise that resolves once the data is recorded.
  */
-function recordPurchaseDeferment(url, wasDeferred) {
+function recordPurchaseDeferment(url, wasDeferred, timerEndTime) {
     var storageKey;
     // Determine the appropriate storage key based on deferment status
     if (wasDeferred === true) {
@@ -97,7 +94,7 @@ function recordPurchaseDeferment(url, wasDeferred) {
             parsedResult = Array(...JSON.parse(storedResult))
         }
         // Add the URL to the appropriate list
-        parsedResult.push(url)
+        parsedResult.unshift({ url: url, timerEndTime: timerEndTime })
         // Store the updated list back to local storage
         const storeValue = {};
         storeValue[storageKey] = JSON.stringify(parsedResult)

--- a/scripts/pages/stats.js
+++ b/scripts/pages/stats.js
@@ -1,7 +1,3 @@
-// Constants for Chrome storage keys
-const DEFERRED_PURCHASES_STORE_KEY = "deferred_purchases";
-const COMPLETED_PURCHASES_STORE_KEY = "completed_purchases";
-
 // IDs for elements where the purchase lists will be displayed
 const DEFERRED_PURCHASES_LIST_ID = "deferred-purchases-list";
 const COMPLETED_PURCHASES_LIST_ID = "completed-purchases-list";
@@ -19,18 +15,6 @@ let completedPurchases = [];
 let deferredPage = 1;
 let completedPage = 1;
 
-/**
- * Retrieves the stored deferred and non-deferred (completed) purchases from Chrome's local storage.
- *
- * @returns {Promise<{ deferred: string[], completed: string[] }>} A promise resolving to an object containing deferred and completed purchases.
- */
-function getStoredPurchases() {
-    return chrome.storage.local.get([DEFERRED_PURCHASES_STORE_KEY, COMPLETED_PURCHASES_STORE_KEY]).then((result) => {
-        const deferred = result[DEFERRED_PURCHASES_STORE_KEY] ? JSON.parse(result[DEFERRED_PURCHASES_STORE_KEY]) : [];
-        const completed = result[COMPLETED_PURCHASES_STORE_KEY] ? JSON.parse(result[COMPLETED_PURCHASES_STORE_KEY]) : [];
-        return { deferred, completed };
-    });
-}
 
 /**
  * Renders a paginated list of purchases in the specified container.
@@ -57,9 +41,11 @@ function renderPaginatedList(purchases, containerId, currentPage) {
     }
 
     // Create list items for each purchase URL
-    paginatedItems.forEach((url, index) => {
+    paginatedItems.forEach((storedInfo, index) => {
         const listItem = document.createElement("li");
-        listItem.textContent = `${startIndex + index + 1}. ${url}`;
+        const url = storedInfo?.url ? storedInfo.url : storedInfo
+        const timerEndTime = storedInfo?.timerEndTime ? ` | ${storedInfo.timerEndTime}` : ''
+        listItem.textContent = `${startIndex + index + 1}. ${url}${timerEndTime}`;
         container.appendChild(listItem);
     });
 
@@ -125,7 +111,8 @@ function renderPaginationControls(container, purchases, currentPage, containerId
     // Append the pagination controls to the container
     if (totalPages !== 1) {
         container.appendChild(paginationDiv);
-    }}
+    }
+}
 
 // Event listener to run once the DOM content is fully loaded
 document.addEventListener("DOMContentLoaded", () => {


### PR DESCRIPTION
# Summary
Added timestamp to feedback statistics. Users can see the time when the timer ended in the stats page
- Moved `getStoredPurchases`, `DEFERRED_PURCHASES_STORE_KEY`, and `COMPLETED_PURCHASES_STORE_KEY`  to `utils.js` to be shared with other files.
- Created `checkIfFeedbackIsProvided` that checks whether the feedback has been provided for a countdown that is done. 
- Hid feedback form if feedback is already provided
- Added `timerEndTime` variable that keeps track of when a timer ended. 
- Fixed link to stats page in the feedback completed section. 

## Before
![image](https://github.com/user-attachments/assets/b01f919d-0eb6-4fab-9c3b-1780aaf30dd4)

## After:
![image](https://github.com/user-attachments/assets/7e5af189-4168-4e76-acf6-4d769a74cb34)
